### PR TITLE
docs: 画面設計・ルーティング仕様・Firestore設計ドラフトを追加

### DIFF
--- a/docs/db/firestore.md
+++ b/docs/db/firestore.md
@@ -1,0 +1,86 @@
+# Firestore 設計メモ（ドラフト）
+
+## 現状データ構造（確認済み）
+
+- `users`
+  - `username` / `email` / `profileImageUrl` / `isOnline` / `createdAt`
+
+- `messages`
+  - `text` / `timestamp` / `senderId` / `senderName` / `receiverId`
+    - `chatId` / `participants[]`
+- `vue-chat`（空）
+
+## 現状の構造（概念図）
+
+```mermaid
+erDiagram
+users ||--o{ messages : sends
+users ||--o{ messages : receives
+
+users {
+    string id
+    string username
+    string email
+    string profileImageUrl
+    boolean isOnline
+    timestamp createdAt
+}
+
+messages {
+    string id
+    string text
+    timestamp timestamp
+    string senderId
+    string senderName
+    string receiverId
+    string chatId
+    string[] participants
+}
+
+```
+
+## 追加予定（設計検討中）
+
+- threads（相談投稿）
+- threadComments（スレッドコメント）
+- directMessages（DM分離）
+
+erDiagram
+users ||--o{ threads : creates
+threads ||--o{ threadComments : has
+users ||--o{ threadComments : posts
+users ||--o{ directMessages : sends
+users ||--o{ directMessages : receives
+
+threads {
+    string id
+    string title
+    string body
+    string[] tags
+    string authorId
+    timestamp createdAt
+    timestamp updatedAt
+}
+
+threadComments {
+    string id
+    string threadId
+    string authorId
+    string body
+    timestamp createdAt
+}
+
+directMessages {
+    string id
+    string chatId
+    string senderId
+    string receiverId
+    string text
+    timestamp timestamp
+}
+
+## 論点メモ
+
+- messages を directMessages に移行するか、互換レイヤーで併用するか
+- threadComments をサブコレクションにするか独立コレクションにするか
+- chatId の生成規則と索引設計

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -1,0 +1,59 @@
+# Routing Specification
+
+このドキュメントは、ルーティング仕様をまとめています。 
+画面遷移の俯瞰は `docs/view-wireframes.drawio` の `FLOW_Navigation` を参照し、最終的な実装判断は本書を基準にします。
+
+## 運用ルール
+
+1. ルーティング変更時は、`src/router/index.js` と本書を同時更新する。
+2. 画面導線レビューは drawio、実装仕様レビューは本書で行う。
+3. `As-Is` は現状把握用、`To-Be` は次の実装ターゲットとして管理する。
+
+## As-Is（現状実装）
+
+参照: [src/router/index.js](/Users/koutaohi/projects/vue-chat/src/router/index.js)
+
+| Path | Route Name | Component | Auth Required | Params | Notes |
+|---|---|---|---|---|---|
+| `/` | `Home` | `HomeView` | No | - | 未ログイン時はHero、ログイン時はUserListを表示 |
+| `/register` | - | `RegisterComponent` | No | - | ログイン済みは`/`へリダイレクト |
+| `/login` | - | `LoginComponent` | No | - | ログイン済みは`/`へリダイレクト |
+| `/profile` | - | `ProfileComponent` | Yes | - | 未ログイン時は`/login`へ |
+| `/users` | `UserList` | `UserList` | Yes | - | 未ログイン時は`/login`へ |
+| `/chat/:userId` | `PrivateChat` | `PrivateChatView` | Yes | `userId` | 未ログイン時は`/login`へ |
+
+## To-Be（設計反映後）
+
+`FLOW_Navigation` と `SCREEN_*` 設計を踏まえたターゲット仕様。
+
+| Path | Route Name (proposal) | Component (proposal) | Auth Required | Params | Notes |
+|---|---|---|---|---|---|
+| `/` | `Home` | `HomeView` | No | - | `SCREEN_Home` |
+| `/login` | `Login` | `LoginComponent` | No | - | `SCREEN_Login` |
+| `/register` | `Register` | `RegisterComponent` | No | - | `SCREEN_Register` |
+| `/users` | `Users` | `UserList` | Yes | - | `SCREEN_Users` |
+| `/chat/:userId` | `PrivateChat` | `PrivateChatView` | Yes | `userId` | `SCREEN_PrivateChat`（1:1 DM専用） |
+| `/profile` | `Profile` | `ProfileComponent` | Yes | - | `SCREEN_Profile` |
+| `/timeline` | `Timeline` | `TimelineView` | Yes | - | `SCREEN_Timeline`（新規） |
+| `/timeline/:postId/thread` | `ThreadDetail` | `ThreadDetailView` | Yes | `postId` | `SCREEN_ThreadDetail`（新規） |
+
+## Guard仕様
+
+### 現状
+
+- 認証必須: `/users`, `/profile`, `/chat/*`
+- 未認証で認証必須ページへアクセス: `/login`へリダイレクト
+- 認証済みで`/login`または`/register`へアクセス: `/`へリダイレクト
+
+### To-Be
+
+- 認証必須: `/users`, `/profile`, `/chat/*`, `/timeline`, `/timeline/*`
+- 未認証で認証必須ページへアクセス: `/login`へリダイレクト
+- 認証済みで`/login`または`/register`へアクセス: `/`へリダイレクト
+
+## 実装反映チェックリスト
+
+1. `src/router/index.js` に `Timeline` / `ThreadDetail` ルートを追加
+2. `beforeEach` の認証必須判定に `/timeline` 系を追加
+3. `Route Name` を表記ゆれなく統一（`Users`, `Login`, `Register`, `Profile`, `Timeline`, `ThreadDetail`）
+4. `FLOW_Navigation` と差分がないことを確認

--- a/docs/view-wireframes.drawio
+++ b/docs/view-wireframes.drawio
@@ -1,0 +1,366 @@
+<mxfile host="65bd71144e">
+    <diagram id="app-shell-page" name="SCREEN_CommonLayout">
+        <mxGraphModel dx="1479" dy="1157" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="800" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="10" value="SCREEN_CommonLayout (Header + router-view)" style="text;html=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=24;align=left;" parent="1" vertex="1">
+                    <mxGeometry x="30" y="20" width="260" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="11" value="&lt;Header /&gt; + &lt;router-view /&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f7ff;strokeColor=#c7d2fe;fontSize=16;" parent="1" vertex="1">
+                    <mxGeometry x="30" y="70" width="1220" height="680" as="geometry"/>
+                </mxCell>
+                <mxCell id="12" value="Header" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d1d5db;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="60" y="100" width="1160" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="13" value="Brand: Real Chat" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#eef2ff;strokeColor=#a5b4fc;" parent="1" link="#Rhome-page" vertex="1">
+                    <mxGeometry x="90" y="120" width="190" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="14" value="Home" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#eef2ff;strokeColor=#a5b4fc;" parent="1" link="#Rhome-page" vertex="1">
+                    <mxGeometry x="310" y="120" width="90" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="15" value="Users" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d1d5db;" parent="1" link="#Rusers-page" vertex="1">
+                    <mxGeometry x="420" y="120" width="90" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="16" value="Profile" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d1d5db;" parent="1" link="#Rprofile-page" vertex="1">
+                    <mxGeometry x="530" y="120" width="90" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="17" value="Login" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#5b6dea;strokeColor=#5b6dea;fontColor=#ffffff;" parent="1" link="#Rlogin-page" vertex="1">
+                    <mxGeometry x="1010" y="120" width="90" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="18" value="Register" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#5b6dea;fontColor=#5b6dea;" parent="1" link="#Rregister-page" vertex="1">
+                    <mxGeometry x="1110" y="120" width="100" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="19" value="router-view (current page content)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d1d5db;" parent="1" vertex="1">
+                    <mxGeometry x="60" y="220" width="1160" height="500" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+    <diagram id="home-page" name="SCREEN_Home">
+        <mxGraphModel dx="1479" dy="1157" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="800" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="100" value="SCREEN_Home (state-based)" style="text;html=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=24;align=left;" parent="1" vertex="1">
+                    <mxGeometry x="30" y="20" width="420" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="107" value="State A: Unauthenticated" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#eef2ff;strokeColor=#93a8ff;fontStyle=1;" vertex="1" parent="1">
+                    <mxGeometry x="70" y="95" width="280" height="34" as="geometry"/>
+                </mxCell>
+                <mxCell id="101" value="LandingHero" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e9eeff;strokeColor=#c7d2fe;" parent="1" vertex="1">
+                    <mxGeometry x="30" y="80" width="1220" height="620" as="geometry"/>
+                </mxCell>
+                <mxCell id="102" value="Left: badge + title + lead + feature list" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dbe4ff;strokeColor=#93a8ff;align=left;spacingLeft=12;" parent="1" vertex="1">
+                    <mxGeometry x="70" y="140" width="610" height="470" as="geometry"/>
+                </mxCell>
+                <mxCell id="103" value="Login CTA\n@login emits" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;fillColor=#5b6dea;strokeColor=#5b6dea;fontColor=#ffffff;" parent="1" link="#Rlogin-page" vertex="1">
+                    <mxGeometry x="100" y="540" width="200" height="48" as="geometry"/>
+                </mxCell>
+                <mxCell id="104" value="Register CTA\n@register emits" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;fillColor=#ffffff;strokeColor=#5b6dea;fontColor=#5b6dea;" parent="1" link="#Rregister-page" vertex="1">
+                    <mxGeometry x="320" y="540" width="220" height="48" as="geometry"/>
+                </mxCell>
+                <mxCell id="105" value="Right: sample_chat.png + caption" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#93a8ff;" parent="1" vertex="1">
+                    <mxGeometry x="730" y="140" width="480" height="470" as="geometry"/>
+                </mxCell>
+                <mxCell id="106" value="State B: Authenticated -&gt; show UserList (same route: /)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fef3c7;strokeColor=#f59e0b;" parent="1" link="#Rusers-page" vertex="1">
+                    <mxGeometry x="70" y="640" width="1140" height="44" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+    <diagram id="login-page" name="SCREEN_Login">
+        <mxGraphModel dx="1479" dy="1157" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="800" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="200" value="SCREEN_Login" style="text;html=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=24;align=left;" parent="1" vertex="1">
+                    <mxGeometry x="30" y="20" width="300" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="201" value="Simple form container" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d1d5db;" parent="1" vertex="1">
+                    <mxGeometry x="340" y="120" width="600" height="470" as="geometry"/>
+                </mxCell>
+                <mxCell id="202" value="h2: Login" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f9fafb;strokeColor=#e5e7eb;" parent="1" vertex="1">
+                    <mxGeometry x="390" y="170" width="500" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="203" value="input: email" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f9fafb;strokeColor=#9ca3af;" parent="1" vertex="1">
+                    <mxGeometry x="390" y="260" width="500" height="56" as="geometry"/>
+                </mxCell>
+                <mxCell id="204" value="input: password" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f9fafb;strokeColor=#9ca3af;" parent="1" vertex="1">
+                    <mxGeometry x="390" y="335" width="500" height="56" as="geometry"/>
+                </mxCell>
+                <mxCell id="205" value="Login button\n(signInWithEmailAndPassword)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#5b6dea;strokeColor=#5b6dea;fontColor=#ffffff;" parent="1" link="#Rhome-page" vertex="1">
+                    <mxGeometry x="390" y="420" width="500" height="56" as="geometry"/>
+                </mxCell>
+                <mxCell id="206" value="Success: router.push({ name: &#39;Home&#39; })" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dcfce7;strokeColor=#16a34a;" parent="1" link="#Rhome-page" vertex="1">
+                    <mxGeometry x="390" y="500" width="500" height="50" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+    <diagram id="register-page" name="SCREEN_Register">
+        <mxGraphModel dx="1479" dy="1157" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="800" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="300" value="SCREEN_Register" style="text;html=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=24;align=left;" parent="1" vertex="1">
+                    <mxGeometry x="30" y="20" width="320" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="301" value="Simple form container" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d1d5db;" parent="1" vertex="1">
+                    <mxGeometry x="340" y="100" width="600" height="520" as="geometry"/>
+                </mxCell>
+                <mxCell id="302" value="h2: Register" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f9fafb;strokeColor=#e5e7eb;" parent="1" vertex="1">
+                    <mxGeometry x="390" y="150" width="500" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="303" value="input: email" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f9fafb;strokeColor=#9ca3af;" parent="1" vertex="1">
+                    <mxGeometry x="390" y="235" width="500" height="56" as="geometry"/>
+                </mxCell>
+                <mxCell id="304" value="input: password" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f9fafb;strokeColor=#9ca3af;" parent="1" vertex="1">
+                    <mxGeometry x="390" y="310" width="500" height="56" as="geometry"/>
+                </mxCell>
+                <mxCell id="305" value="input: username" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f9fafb;strokeColor=#9ca3af;" parent="1" vertex="1">
+                    <mxGeometry x="390" y="385" width="500" height="56" as="geometry"/>
+                </mxCell>
+                <mxCell id="306" value="Register button\n(createUserWithEmailAndPassword)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#5b6dea;strokeColor=#5b6dea;fontColor=#ffffff;" parent="1" link="#Rhome-page" vertex="1">
+                    <mxGeometry x="390" y="470" width="500" height="56" as="geometry"/>
+                </mxCell>
+                <mxCell id="307" value="Success: router.push(&#39;/&#39;)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dcfce7;strokeColor=#16a34a;" parent="1" link="#Rhome-page" vertex="1">
+                    <mxGeometry x="390" y="550" width="500" height="50" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+    <diagram id="users-page" name="SCREEN_Users">
+        <mxGraphModel dx="1479" dy="1157" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="800" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="400" value="SCREEN_Users (/users)" style="text;html=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=24;align=left;" parent="1" vertex="1">
+                    <mxGeometry x="30" y="20" width="300" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="401" value="h2: User List" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d1d5db;" parent="1" vertex="1">
+                    <mxGeometry x="50" y="80" width="1180" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="402" value="user-card (v-for)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f9fafb;strokeColor=#d1d5db;" parent="1" vertex="1">
+                    <mxGeometry x="120" y="170" width="1040" height="130" as="geometry"/>
+                </mxCell>
+                <mxCell id="403" value="avatar" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d1d5db;strokeColor=#9ca3af;" parent="1" vertex="1">
+                    <mxGeometry x="155" y="205" width="60" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="404" value="username / email / online status" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d1d5db;align=left;spacingLeft=12;" parent="1" vertex="1">
+                    <mxGeometry x="240" y="195" width="600" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="405" value="open chat (router-link :to PrivateChat)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dbeafe;strokeColor=#60a5fa;" parent="1" link="#Rprivatechat-page" vertex="1">
+                    <mxGeometry x="870" y="195" width="260" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="406" value="...repeat cards..." style="text;html=1;strokeColor=none;fillColor=none;fontSize=18;color=#6b7280;" parent="1" vertex="1">
+                    <mxGeometry x="550" y="340" width="200" height="30" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+    <diagram id="timeline-page" name="SCREEN_Timeline">
+        <mxGraphModel dx="1479" dy="1157" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="800" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="700" value="SCREEN_Timeline (/timeline)" style="text;html=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=24;align=left;" parent="1" vertex="1">
+                    <mxGeometry x="30" y="20" width="360" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="701" value="Post list (reverse chronological)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d1d5db;" parent="1" vertex="1">
+                    <mxGeometry x="50" y="80" width="1180" height="650" as="geometry"/>
+                </mxCell>
+                <mxCell id="702" value="Post card" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f9fafb;strokeColor=#d1d5db;" parent="1" vertex="1">
+                    <mxGeometry x="110" y="140" width="1060" height="150" as="geometry"/>
+                </mxCell>
+                <mxCell id="703" value="author / postedAt / body" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#9ca3af;align=left;spacingLeft=12;" parent="1" vertex="1">
+                    <mxGeometry x="140" y="170" width="700" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="704" value="comment count" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#eef2ff;strokeColor=#93a8ff;" parent="1" vertex="1">
+                    <mxGeometry x="860" y="170" width="130" height="42" as="geometry"/>
+                </mxCell>
+                <mxCell id="705" value="Open Thread" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dbeafe;strokeColor=#60a5fa;" parent="1" link="#Rthread-detail-page" vertex="1">
+                    <mxGeometry x="1000" y="170" width="150" height="42" as="geometry"/>
+                </mxCell>
+                <mxCell id="706" value="...repeat post cards..." style="text;html=1;strokeColor=none;fillColor=none;fontSize=18;color=#6b7280;" parent="1" vertex="1">
+                    <mxGeometry x="520" y="340" width="240" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="707" value="New post composer (optional in this screen)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fef3c7;strokeColor=#f59e0b;" parent="1" vertex="1">
+                    <mxGeometry x="110" y="640" width="1060" height="60" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+    <diagram id="thread-detail-page" name="SCREEN_ThreadDetail">
+        <mxGraphModel dx="1479" dy="1157" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="800" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="800" value="SCREEN_ThreadDetail (/timeline/:postId/thread)" style="text;html=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=24;align=left;" parent="1" vertex="1">
+                    <mxGeometry x="30" y="20" width="560" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="801" value="Back to Timeline" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e5e7eb;strokeColor=#9ca3af;" parent="1" link="#Rtimeline-page" vertex="1">
+                    <mxGeometry x="50" y="80" width="170" height="42" as="geometry"/>
+                </mxCell>
+                <mxCell id="802" value="Target post summary (author / body / postedAt)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#eef2ff;strokeColor=#93a8ff;align=left;spacingLeft=12;" parent="1" vertex="1">
+                    <mxGeometry x="50" y="140" width="1180" height="120" as="geometry"/>
+                </mxCell>
+                <mxCell id="803" value="Comments list" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d1d5db;" parent="1" vertex="1">
+                    <mxGeometry x="50" y="280" width="1180" height="360" as="geometry"/>
+                </mxCell>
+                <mxCell id="804" value="comment item (author / text / postedAt)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f9fafb;strokeColor=#d1d5db;align=left;spacingLeft=12;" parent="1" vertex="1">
+                    <mxGeometry x="90" y="320" width="1100" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="805" value="...repeat comments..." style="text;html=1;strokeColor=none;fillColor=none;fontSize=18;color=#6b7280;" parent="1" vertex="1">
+                    <mxGeometry x="520" y="445" width="230" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="806" value="Comment input + Post button" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#9ca3af;" parent="1" vertex="1">
+                    <mxGeometry x="50" y="660" width="1180" height="80" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+    <diagram id="privatechat-page" name="SCREEN_PrivateChat">
+        <mxGraphModel dx="1479" dy="1157" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="800" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="500" value="SCREEN_PrivateChat (/chat/:userId)" style="text;html=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=24;align=left;" parent="1" vertex="1">
+                    <mxGeometry x="30" y="20" width="420" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="501" value="Home button" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b82f6;strokeColor=#2563eb;fontColor=#ffffff;" parent="1" link="#Rhome-page" vertex="1">
+                    <mxGeometry x="50" y="90" width="120" height="44" as="geometry"/>
+                </mxCell>
+                <mxCell id="502" value="chat-container" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#d1d5db;" parent="1" vertex="1">
+                    <mxGeometry x="50" y="150" width="1180" height="560" as="geometry"/>
+                </mxCell>
+                <mxCell id="503" value="h2: Chat with {{ chatPartnerName }}" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d1d5db;" parent="1" vertex="1">
+                    <mxGeometry x="80" y="180" width="1120" height="56" as="geometry"/>
+                </mxCell>
+                <mxCell id="504" value="messages list (onSnapshot query + orderBy timestamp)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#9ca3af;align=left;spacingLeft=12;" parent="1" vertex="1">
+                    <mxGeometry x="80" y="250" width="1120" height="330" as="geometry"/>
+                </mxCell>
+                <mxCell id="505" value="input + Send button" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#9ca3af;" parent="1" vertex="1">
+                    <mxGeometry x="80" y="600" width="1120" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="506" value="1:1 direct message UI only (separate from thread comments)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fef3c7;strokeColor=#f59e0b;align=left;spacingLeft=12;" vertex="1" parent="1">
+                    <mxGeometry x="80" y="710" width="1120" height="46" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+    <diagram id="profile-page" name="SCREEN_Profile">
+        <mxGraphModel dx="1479" dy="1157" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="800" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="600" value="SCREEN_Profile (/profile)" style="text;html=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=24;align=left;" parent="1" vertex="1">
+                    <mxGeometry x="30" y="20" width="380" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="601" value="h2: Profile" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d1d5db;" parent="1" vertex="1">
+                    <mxGeometry x="120" y="120" width="1040" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="602" value="if user: show Email\nelse: No user is logged in" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f9fafb;strokeColor=#d1d5db;align=left;spacingLeft=12;" parent="1" vertex="1">
+                    <mxGeometry x="120" y="220" width="1040" height="100" as="geometry"/>
+                </mxCell>
+                <mxCell id="603" value="Note: ChatView import is commented out in current code" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fef3c7;strokeColor=#f59e0b;" parent="1" vertex="1">
+                    <mxGeometry x="120" y="350" width="1040" height="70" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+    <diagram id="nav-flow-page" name="FLOW_Navigation">
+        <mxGraphModel dx="1215" dy="1157" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1000" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="10" value="FLOW_Navigation" style="text;html=1;strokeColor=none;fillColor=none;fontStyle=1;fontSize=28;" parent="1" vertex="1">
+                    <mxGeometry x="40" y="20" width="500" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="20" value="Home\n/" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e0e7ff;strokeColor=#6366f1;fontStyle=1;" parent="1" link="#Rhome-page" vertex="1">
+                    <mxGeometry x="260" y="130" width="220" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="21" value="Login\n/login" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fee2e2;strokeColor=#ef4444;fontStyle=1;" parent="1" link="#Rlogin-page" vertex="1">
+                    <mxGeometry x="640" y="130" width="220" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="22" value="Register\n/register" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fef3c7;strokeColor=#f59e0b;fontStyle=1;" parent="1" link="#Rregister-page" vertex="1">
+                    <mxGeometry x="1020" y="130" width="220" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="P59ds_6_myYTN52-55Zv-50" value="" style="edgeStyle=none;html=1;" edge="1" parent="1" source="23" target="26">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="23" value="Users\n/users\n(auth required)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dcfce7;strokeColor=#22c55e;fontStyle=1;" parent="1" link="#Rusers-page" vertex="1">
+                    <mxGeometry x="110" y="340" width="220" height="100" as="geometry"/>
+                </mxCell>
+                <mxCell id="24" value="PrivateChat\n/chat/:userId\n(auth required)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dbeafe;strokeColor=#3b82f6;fontStyle=1;" parent="1" link="#Rprivatechat-page" vertex="1">
+                    <mxGeometry x="640" y="360" width="220" height="100" as="geometry"/>
+                </mxCell>
+                <mxCell id="25" value="Profile\n/profile\n(auth required)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f3e8ff;strokeColor=#a855f7;fontStyle=1;" parent="1" link="#Rprofile-page" vertex="1">
+                    <mxGeometry x="1020" y="360" width="220" height="100" as="geometry"/>
+                </mxCell>
+                <mxCell id="26" value="Timeline\n/timeline\n(auth required)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fef3c7;strokeColor=#f59e0b;fontStyle=1;" vertex="1" link="#Rtimeline-page" parent="1">
+                    <mxGeometry x="260" y="510" width="220" height="100" as="geometry"/>
+                </mxCell>
+                <mxCell id="27" value="ThreadDetail\n/timeline/:postId/thread\n(auth required)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fee2e2;strokeColor=#ef4444;fontStyle=1;" vertex="1" link="#Rthread-detail-page" parent="1">
+                    <mxGeometry x="640" y="510" width="220" height="100" as="geometry"/>
+                </mxCell>
+                <mxCell id="30" value="not logged in" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#ef4444;" parent="1" source="23" target="21" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="31" value="not logged in" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#ef4444;" parent="1" source="24" target="21" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="32" value="not logged in" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#ef4444;" parent="1" source="25" target="21" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="41" value="not logged in" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#ef4444;" edge="1" parent="1" source="26" target="21">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="42" value="not logged in" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#ef4444;" edge="1" parent="1" source="27" target="21">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="33" value="already logged in" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#16a34a;" parent="1" source="21" target="20" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="34" value="already logged in" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#16a34a;" parent="1" source="22" target="20" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="35" value="header nav" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#6366f1;" parent="1" source="20" target="23" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="36" value="header nav" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#6366f1;" parent="1" source="20" target="25" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="43" value="header nav" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#6366f1;" edge="1" parent="1" source="20" target="26">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="370" y="400"/>
+                            <mxPoint x="370" y="400"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="37" value="card click" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#0ea5e9;" parent="1" source="23" target="24" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="38" value="Home button" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#0ea5e9;" parent="1" source="24" target="20" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="39" value="hero CTA" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#6366f1;" parent="1" source="20" target="21" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="40" value="hero CTA" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#6366f1;" parent="1" source="20" target="22" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="44" value="post click / comment" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#0ea5e9;" edge="1" parent="1" source="26" target="27">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="45" value="back to timeline" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#0ea5e9;" edge="1" parent="1" source="27" target="26">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="50" value="Guard rule (router.beforeEach):\n/users, /profile, /chat/*, /timeline, /timeline/* require auth\nIf unauthenticated -&gt; /login\nIf authenticated and target is /login or /register -&gt; /" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f9fafb;strokeColor=#9ca3af;align=left;spacingLeft=12;spacingTop=10;" parent="1" vertex="1">
+                    <mxGeometry x="210" y="660" width="980" height="200" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>


### PR DESCRIPTION
## 概要
画面設計とルーティング仕様、およびFirestore設計ドラフトをドキュメントとして追加しました。  
設計の正本を `docs/` に集約し、今後の実装判断とレビューの基準を明確化することが目的です。

## 変更内容
- `docs/view-wireframes.drawio` を追加
  - 画面ページを `SCREEN_*` 命名で整理
  - `FLOW_Navigation` を追加・更新
  - Timeline / ThreadDetail 導線を反映
  - PrivateChat は 1:1 DM 専用であることを明記
- `docs/routes.md` を追加
  - ルーティングの `As-Is` / `To-Be` を整理
  - Guard仕様と実装反映チェックリストを定義
- `docs/db/firestore.md` を追加
  - 現状データ構造の整理
  - threads / threadComments / directMessages の拡張案を記載
  - 今後の論点（移行方針、コレクション設計、索引）を明文化

## 背景
- 画面遷移とルート仕様、DB設計の議論が分散していたため、設計レビューしやすい形に統一する必要があったため。
- 実装前に「設計の合意ポイント」を固定するため。

## スコープ
- ドキュメント追加のみ（実装コード変更なし）

## レビュー観点
- 画面導線がプロダクト意図と一致しているか
- `routes.md` の To-Be が今後実装するルーティング方針として妥当か
- Firestore拡張案（threads/comment/DM分離）の方向性が妥当か
