### PR TITLE
#29 Firestore の read/write 権限方針を整理する

### DIFF
--- a/docs/db/firestore-authz.md
+++ b/docs/db/firestore-authz.md
@@ -27,10 +27,10 @@
 
 | コレクション | read | create | update | delete |
 |---|---|---|---|---|
-| `users/{userId}` | 認証ユーザーのみ | 本人のみ | 本人のみ | 原則なし |
+| `users/{userId}` | 認証ユーザーのみ | 本人のみ | 本人のみ | 当面は許可しない |
 | `threads/{threadId}` | 認証ユーザーのみ | 認証ユーザー本人 | 原則作成者本人のみ | 原則作成者本人のみ |
 | `threads/{threadId}/comments/{commentId}` | 認証ユーザーのみ | 認証ユーザー本人 | 原則作成者本人のみ | 原則作成者本人のみ |
-| `directMessages/{messageId}` | 当事者のみ | 送信者本人のみ | 原則なし | 原則なし |
+| `directMessages/{messageId}` | 当事者のみ | 送信者本人のみ | 当面は許可しない | 当面は許可しない |
 
 ## コレクション別方針
 


### PR DESCRIPTION
## 概要
`#29 コレクションごとの read/write 権限方針を整理する` に対応する文書を追加します。

## 変更内容
- `docs/db/firestore-authz.md` を追加
- `users` `threads` `comments` `directMessages` の権限方針を整理
- Rules 実装時の前提と未確定事項を分離

## レビュー観点
- Issue #29 の完了条件を満たしているか
- read/create/update/delete の整理が十分か
- `#26` `#27` に依存する未確定事項の切り分けが適切か

## 関連 Issue
- Closes #29
