### PR TITLE
#45 Firestore Security Rules を実装する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - 開発サーバー: `npm run serve`
 - 本番ビルド: `npm run build`
 - Lint: `npm run lint`
+- Firestore Rules 検証: `npm run test:rules`
 - Firebase CLI を使う場合は `npm install -g firebase-tools` → `firebase login` → `firebase init`（必要に応じて）→ `firebase emulators:start` / `firebase deploy` などのフローを利用。
 
 ## Obsidian ノート

--- a/docs/session-memory/audit.md
+++ b/docs/session-memory/audit.md
@@ -263,3 +263,9 @@
 - `/tmp/java-runtime/jdk-21.0.10+7-jre/Contents/Home` に展開した Temurin JRE 21 を使って Firestore emulator を起動できる状態にした
 - `firebase.json` の emulator ポートを auth `9199` / firestore `8180` に寄せた前提で、`scripts/verify-firestore-rules.mjs` が `FIREBASE_AUTH_EMULATOR_HOST` / `FIRESTORE_EMULATOR_HOST` を読むよう修正した
 - `npm run test:rules` を再実行し、`users` `threads` `threads/{threadId}/comments` `directMessages` の許可 / 拒否ケースがすべて PASS することを確認した
+
+## 2026-03-22T11:25:00Z
+
+- `#45 Firestore Security Rules と検証スクリプトを追加` を commit した
+- branch `issue-45-security-rules` を push し、通常 PR `#62` `#45 Firestore Security Rules を実装する` を作成した
+- PR 作成時に `assignee` として `ohikouta` を設定した

--- a/docs/session-memory/audit.md
+++ b/docs/session-memory/audit.md
@@ -242,3 +242,24 @@
 
 - PR 作成時の追加運用として、原則ユーザー（`ohikouta`）を assignee に設定する方針を確認した
 - `AGENTS.md` と `summary.md` に同方針を追記し、以後の PR 作成手順へ反映する前提を明文化した
+
+## 2026-03-22T08:20:00Z
+
+- Issue `#45` の着手として `/tmp/vue-chat-45` worktree で `firestore.rules` を新規追加した
+- `users` `threads` `threads/{threadId}/comments` `directMessages` の read / create / update / delete 制御を `docs/db/firestore-authz.md` に沿って Rules 化した
+- `firebase.json` に Firestore Rules パスと auth / firestore emulator 設定を追加した
+- `scripts/verify-firestore-rules.mjs` と `npm run test:rules` を追加し、Auth emulator の ID token を使って Rules を通過 / 拒否確認する検証スクリプトを用意した
+- `AGENTS.md` に `npm run test:rules` を追記した
+- `npm run lint` は成功した
+- `npm run test:rules` は Firestore emulator 起動に Java Runtime が必要なため、現環境では `java -version` 不在で未完了になった
+
+## 2026-03-22T08:45:00Z
+
+- Java Runtime 導入を試みたが、Homebrew / 直ダウンロードともにネットワーク速度がボトルネックとなり、このターンでは完了しなかった
+- Firestore emulator を使う `npm run test:rules` は次回継続課題として扱う
+
+## 2026-03-22T11:11:00Z
+
+- `/tmp/java-runtime/jdk-21.0.10+7-jre/Contents/Home` に展開した Temurin JRE 21 を使って Firestore emulator を起動できる状態にした
+- `firebase.json` の emulator ポートを auth `9199` / firestore `8180` に寄せた前提で、`scripts/verify-firestore-rules.mjs` が `FIREBASE_AUTH_EMULATOR_HOST` / `FIRESTORE_EMULATOR_HOST` を読むよう修正した
+- `npm run test:rules` を再実行し、`users` `threads` `threads/{threadId}/comments` `directMessages` の許可 / 拒否ケースがすべて PASS することを確認した

--- a/docs/session-memory/summary.md
+++ b/docs/session-memory/summary.md
@@ -1,7 +1,7 @@
 # Project Summary
 
-- Updated At: 2026-03-22T02:55:00Z
-- Branch: issue-56-clean-main
+- Updated At: 2026-03-22T11:11:00Z
+- Branch: issue-45-security-rules
 - HEAD: f02dfd05
 - Updated By: Codex
 
@@ -12,7 +12,7 @@
 - `#30` は完了し、PR `#34` は merge 済み
 - `#44` は完了し、PR `#59` は merge 済み
 - `#46` は完了し、PR `#60` は merge 済み
-- 現在の open Issue は `#45` `#48` `#56`
+- 現在の open Issue は `#45` `#48`
 - Firestore 設計の基準は [firestore.md](../db/firestore.md)
 
 ## Recent Progress
@@ -41,6 +41,7 @@
 - `src/router/index.js` の route name と guard 判定を整理し、`docs/routes.md` など関連ドキュメントを同期
 - `npm run lint` を実行し、lint error なしを確認
 - `#52` が merge され、`#47` の画面責務整理が `main` に取り込まれた
+<<<<<<< HEAD
 - `#53` が merge され、`#40` の相談投稿と新着一覧が `main` に取り込まれた
 - `#54` のレビュー対応で `ThreadDetailView` の route param 変更追従と無効投稿ガードを追加した
 - `#42` の参加者一覧表示を実装し、`authorId` 優先集約で表示方針を整理した
@@ -55,6 +56,13 @@
 - `AGENTS.md` の承認ポリシーへ `gh api` read/write の境界を追記した
 - PR 作成フローとして、通常 PR を原則とし、draft PR は明確な未完理由がある場合に限る方針を明文化した
 - PR 作成時は原則としてユーザー（`ohikouta`）を assignee に設定する方針を追加した
+- `#45` の着手として `firestore.rules` を新規追加し、`users` `threads` `threads/{threadId}/comments` `directMessages` の Rules を実装した
+- `firebase.json` に Firestore Rules と auth / firestore emulator 設定を追加した
+- `scripts/verify-firestore-rules.mjs` と `npm run test:rules` を追加し、Auth emulator の ID token 経由で Rules を検証するスクリプトを用意した
+- `npm run lint` は成功した
+- `/tmp/java-runtime/jdk-21.0.10+7-jre/Contents/Home` に展開した JRE 21 を使って Firestore emulator を起動できる状態にした
+- `scripts/verify-firestore-rules.mjs` が emulator の `*_HOST` 環境変数と現行ポート設定 `9199` / `8180` を読むよう修正した
+- `npm run test:rules` を実行し、`users` `threads` `comments` `directMessages` の許可 / 拒否ケースがすべて PASS することを確認した
 
 ## Current Decisions
 
@@ -92,11 +100,12 @@
 - GitHub の Issue / PR 状態を更新したターンでは、対応する Obsidian `タスク.md` も同ターンで同期する
 - PR は原則として通常 PR で作成し、draft PR は明確な未完理由がある場合に限る
 - PR 作成時は原則としてユーザー（`ohikouta`）を assignee に設定する
+- Firestore Rules は `users` を認証ユーザー限定、`threads` / `comments` を認証 + author 基準、`directMessages` を当事者限定 + sender 基準で扱う
+- Firestore Rules 検証は `/tmp/java-runtime/jdk-21.0.10+7-jre/Contents/Home` の一時 JRE を使って emulator 上で実行できる
 
 ## Next Actions
 
-- Issue `#56` の差分を `main` 起点の clean branch で PR に載せ直す
-- `#56` の整理後、`#45` または `#48` の着手順を決める
+- `#45` の差分を branch / PR にまとめる
 
 ## Reference Logs
 

--- a/docs/session-memory/summary.md
+++ b/docs/session-memory/summary.md
@@ -1,8 +1,8 @@
 # Project Summary
 
-- Updated At: 2026-03-22T11:11:00Z
+- Updated At: 2026-03-22T11:25:00Z
 - Branch: issue-45-security-rules
-- HEAD: f02dfd05
+- HEAD: dcf72c40
 - Updated By: Codex
 
 ## Current Status
@@ -63,6 +63,7 @@
 - `/tmp/java-runtime/jdk-21.0.10+7-jre/Contents/Home` に展開した JRE 21 を使って Firestore emulator を起動できる状態にした
 - `scripts/verify-firestore-rules.mjs` が emulator の `*_HOST` 環境変数と現行ポート設定 `9199` / `8180` を読むよう修正した
 - `npm run test:rules` を実行し、`users` `threads` `comments` `directMessages` の許可 / 拒否ケースがすべて PASS することを確認した
+- `#45 Firestore Security Rules と検証スクリプトを追加` を commit し、PR `#62` を通常 PR として作成した
 
 ## Current Decisions
 
@@ -105,7 +106,7 @@
 
 ## Next Actions
 
-- `#45` の差分を branch / PR にまとめる
+- PR `#62` の Copilot レビューを確認し、必要な修正を反映する
 
 ## Reference Logs
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,29 @@
 {
   "firestore": {
+    "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
+  },
+  "emulators": {
+    "auth": {
+      "host": "127.0.0.1",
+      "port": 9199
+    },
+    "firestore": {
+      "host": "127.0.0.1",
+      "port": 8180,
+      "websocketPort": 9250
+    },
+    "hub": {
+      "host": "127.0.0.1",
+      "port": 4401
+    },
+    "logging": {
+      "host": "127.0.0.1",
+      "port": 4501
+    },
+    "ui": {
+      "enabled": false
+    },
+    "singleProjectMode": true
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,226 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function signedIn() {
+      return request.auth != null;
+    }
+
+    function isSelf(userId) {
+      return signedIn() && request.auth.uid == userId;
+    }
+
+    function optionalString(data, field) {
+      return !data.keys().hasAny([field]) || data[field] is string;
+    }
+
+    function optionalTimestamp(data, field) {
+      return !data.keys().hasAny([field]) || data[field] is timestamp;
+    }
+
+    function optionalList(data, field) {
+      return !data.keys().hasAny([field]) || data[field] is list;
+    }
+
+    function optionalNumber(data, field) {
+      return !data.keys().hasAny([field]) || data[field] is number;
+    }
+
+    function userDocExists(userId) {
+      return exists(/databases/$(database)/documents/users/$(userId));
+    }
+
+    match /users/{userId} {
+      allow read: if signedIn();
+
+      allow create: if isSelf(userId)
+        && request.resource.data.keys().hasOnly([
+          'displayName',
+          'username',
+          'email',
+          'profileImageUrl',
+          'isOnline',
+          'createdAt',
+          'updatedAt'
+        ])
+        && request.resource.data.email is string
+        && optionalString(request.resource.data, 'displayName')
+        && optionalString(request.resource.data, 'username')
+        && optionalString(request.resource.data, 'profileImageUrl')
+        && (!request.resource.data.keys().hasAny(['isOnline']) || request.resource.data.isOnline is bool)
+        && optionalTimestamp(request.resource.data, 'createdAt')
+        && optionalTimestamp(request.resource.data, 'updatedAt');
+
+      allow update: if isSelf(userId)
+        && request.resource.data.keys().hasOnly([
+          'displayName',
+          'username',
+          'email',
+          'profileImageUrl',
+          'isOnline',
+          'createdAt',
+          'updatedAt'
+        ])
+        && request.resource.data.email is string
+        && optionalString(request.resource.data, 'displayName')
+        && optionalString(request.resource.data, 'username')
+        && optionalString(request.resource.data, 'profileImageUrl')
+        && (!request.resource.data.keys().hasAny(['isOnline']) || request.resource.data.isOnline is bool)
+        && optionalTimestamp(request.resource.data, 'createdAt')
+        && optionalTimestamp(request.resource.data, 'updatedAt')
+        && (
+          !resource.data.keys().hasAny(['createdAt'])
+          || request.resource.data.createdAt == resource.data.createdAt
+        );
+
+      allow delete: if false;
+    }
+
+    match /threads/{threadId} {
+      allow read: if signedIn();
+
+      allow create: if signedIn()
+        && request.resource.data.keys().hasOnly([
+          'title',
+          'body',
+          'tags',
+          'authorId',
+          'authorName',
+          'commentCount',
+          'lastCommentAt',
+          'createdAt',
+          'updatedAt'
+        ])
+        && request.resource.data.keys().hasAll([
+          'title',
+          'body',
+          'authorId',
+          'authorName',
+          'createdAt',
+          'updatedAt'
+        ])
+        && request.resource.data.title is string
+        && request.resource.data.body is string
+        && request.resource.data.authorId == request.auth.uid
+        && request.resource.data.authorName is string
+        && optionalList(request.resource.data, 'tags')
+        && optionalNumber(request.resource.data, 'commentCount')
+        && optionalTimestamp(request.resource.data, 'lastCommentAt')
+        && request.resource.data.createdAt is timestamp
+        && request.resource.data.updatedAt is timestamp;
+
+      allow update: if signedIn()
+        && resource.data.authorId == request.auth.uid
+        && request.resource.data.keys().hasOnly([
+          'title',
+          'body',
+          'tags',
+          'authorId',
+          'authorName',
+          'commentCount',
+          'lastCommentAt',
+          'createdAt',
+          'updatedAt'
+        ])
+        && request.resource.data.title is string
+        && request.resource.data.body is string
+        && request.resource.data.authorId == resource.data.authorId
+        && request.resource.data.authorName == resource.data.authorName
+        && optionalList(request.resource.data, 'tags')
+        && optionalNumber(request.resource.data, 'commentCount')
+        && optionalTimestamp(request.resource.data, 'lastCommentAt')
+        && request.resource.data.createdAt == resource.data.createdAt
+        && request.resource.data.updatedAt is timestamp;
+
+      allow delete: if signedIn() && resource.data.authorId == request.auth.uid;
+
+      match /comments/{commentId} {
+        allow read: if signedIn();
+
+        allow create: if signedIn()
+          && request.resource.data.keys().hasOnly([
+            'body',
+            'authorId',
+            'authorName',
+            'createdAt',
+            'updatedAt',
+            'parentCommentId'
+          ])
+          && request.resource.data.keys().hasAll([
+            'body',
+            'authorId',
+            'authorName',
+            'createdAt',
+            'updatedAt'
+          ])
+          && request.resource.data.body is string
+          && request.resource.data.authorId == request.auth.uid
+          && request.resource.data.authorName is string
+          && request.resource.data.createdAt is timestamp
+          && request.resource.data.updatedAt is timestamp
+          && optionalString(request.resource.data, 'parentCommentId');
+
+        allow update: if signedIn()
+          && resource.data.authorId == request.auth.uid
+          && request.resource.data.keys().hasOnly([
+            'body',
+            'authorId',
+            'authorName',
+            'createdAt',
+            'updatedAt',
+            'parentCommentId'
+          ])
+          && request.resource.data.body is string
+          && request.resource.data.authorId == resource.data.authorId
+          && request.resource.data.authorName == resource.data.authorName
+          && request.resource.data.createdAt == resource.data.createdAt
+          && request.resource.data.updatedAt is timestamp
+          && (
+            !resource.data.keys().hasAny(['parentCommentId'])
+            || request.resource.data.parentCommentId == resource.data.parentCommentId
+          )
+          && optionalString(request.resource.data, 'parentCommentId');
+
+        allow delete: if signedIn() && resource.data.authorId == request.auth.uid;
+      }
+    }
+
+    match /directMessages/{messageId} {
+      allow read: if signedIn()
+        && (
+          resource.data.senderId == request.auth.uid
+          || resource.data.receiverId == request.auth.uid
+        );
+
+      allow create: if signedIn()
+        && request.resource.data.keys().hasOnly([
+          'chatId',
+          'senderId',
+          'senderName',
+          'receiverId',
+          'text',
+          'createdAt'
+        ])
+        && request.resource.data.keys().hasAll([
+          'chatId',
+          'senderId',
+          'senderName',
+          'receiverId',
+          'text',
+          'createdAt'
+        ])
+        && request.resource.data.chatId is string
+        && request.resource.data.chatId.size() > 0
+        && request.resource.data.senderId == request.auth.uid
+        && request.resource.data.senderId is string
+        && request.resource.data.receiverId is string
+        && request.resource.data.senderId != request.resource.data.receiverId
+        && request.resource.data.senderName is string
+        && request.resource.data.text is string
+        && request.resource.data.createdAt is timestamp
+        && userDocExists(request.resource.data.receiverId);
+
+      allow update, delete: if false;
+    }
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -30,6 +30,24 @@ service cloud.firestore {
       return exists(/databases/$(database)/documents/users/$(userId));
     }
 
+    function authEmail() {
+      return request.auth.token.email;
+    }
+
+    function orderedUidA(userId1, userId2) {
+      return userId1 <= userId2 ? userId1 : userId2;
+    }
+
+    function orderedUidB(userId1, userId2) {
+      return userId1 <= userId2 ? userId2 : userId1;
+    }
+
+    function chatIdMatchesParticipants(chatId, userId1, userId2) {
+      let uidA = orderedUidA(userId1, userId2);
+      let uidB = orderedUidB(userId1, userId2);
+      return chatId.matches("^dm:v1:[0-9]+:" + uidA + "\\|[0-9]+:" + uidB + "$");
+    }
+
     match /users/{userId} {
       allow read: if signedIn();
 
@@ -44,6 +62,8 @@ service cloud.firestore {
           'updatedAt'
         ])
         && request.resource.data.email is string
+        && authEmail() is string
+        && request.resource.data.email == authEmail()
         && optionalString(request.resource.data, 'displayName')
         && optionalString(request.resource.data, 'username')
         && optionalString(request.resource.data, 'profileImageUrl')
@@ -62,6 +82,9 @@ service cloud.firestore {
           'updatedAt'
         ])
         && request.resource.data.email is string
+        && authEmail() is string
+        && request.resource.data.email == resource.data.email
+        && request.resource.data.email == authEmail()
         && optionalString(request.resource.data, 'displayName')
         && optionalString(request.resource.data, 'username')
         && optionalString(request.resource.data, 'profileImageUrl')
@@ -129,6 +152,14 @@ service cloud.firestore {
         && optionalList(request.resource.data, 'tags')
         && optionalNumber(request.resource.data, 'commentCount')
         && optionalTimestamp(request.resource.data, 'lastCommentAt')
+        && (
+          !request.resource.data.keys().hasAny(['commentCount'])
+          || request.resource.data.commentCount == resource.data.commentCount
+        )
+        && (
+          !request.resource.data.keys().hasAny(['lastCommentAt'])
+          || request.resource.data.lastCommentAt == resource.data.lastCommentAt
+        )
         && request.resource.data.createdAt == resource.data.createdAt
         && request.resource.data.updatedAt is timestamp;
 
@@ -215,6 +246,11 @@ service cloud.firestore {
         && request.resource.data.senderId is string
         && request.resource.data.receiverId is string
         && request.resource.data.senderId != request.resource.data.receiverId
+        && chatIdMatchesParticipants(
+          request.resource.data.chatId,
+          request.resource.data.senderId,
+          request.resource.data.receiverId
+        )
         && request.resource.data.senderName is string
         && request.resource.data.text is string
         && request.resource.data.createdAt is timestamp

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "test:rules": "mkdir -p /tmp/firebase-config && XDG_CONFIG_HOME=/tmp/firebase-config FIREBASE_SKIP_UPDATE_CHECK=1 firebase emulators:exec --only auth,firestore --project demo-real-chat \"node scripts/verify-firestore-rules.mjs\""
+    "test:rules": "node scripts/run-firestore-rules-test.mjs"
   },
   "dependencies": {
     "core-js": "^3.8.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "test:rules": "mkdir -p /tmp/firebase-config && XDG_CONFIG_HOME=/tmp/firebase-config FIREBASE_SKIP_UPDATE_CHECK=1 firebase emulators:exec --only auth,firestore --project demo-real-chat \"node scripts/verify-firestore-rules.mjs\""
   },
   "dependencies": {
     "core-js": "^3.8.3",

--- a/scripts/run-firestore-rules-test.mjs
+++ b/scripts/run-firestore-rules-test.mjs
@@ -1,0 +1,47 @@
+import { mkdirSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const configDir = path.join(os.tmpdir(), 'firebase-config');
+
+mkdirSync(configDir, { recursive: true });
+
+const env = {
+  ...process.env,
+  XDG_CONFIG_HOME: configDir,
+  FIREBASE_SKIP_UPDATE_CHECK: '1'
+};
+
+const firebaseCommand = process.platform === 'win32' ? 'firebase.cmd' : 'firebase';
+
+const result = spawnSync(
+  firebaseCommand,
+  [
+    'emulators:exec',
+    '--only',
+    'auth,firestore',
+    '--project',
+    'demo-real-chat',
+    'node scripts/verify-firestore-rules.mjs'
+  ],
+  {
+    stdio: 'inherit',
+    env
+  }
+);
+
+if (result.error) {
+  console.error(result.error);
+  process.exit(1);
+}
+
+if (result.signal) {
+  console.error(`firebase emulators:exec was terminated by signal: ${result.signal}`);
+}
+
+if (typeof result.status === 'number' && result.status !== 0) {
+  console.error(`firebase emulators:exec exited with status: ${result.status}`);
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/verify-firestore-rules.mjs
+++ b/scripts/verify-firestore-rules.mjs
@@ -1,0 +1,423 @@
+const projectId = process.env.FIREBASE_EMULATOR_PROJECT_ID || 'demo-real-chat';
+
+function toBaseUrl(explicitUrl, hostEnv, fallbackPort) {
+  if (explicitUrl) {
+    return explicitUrl;
+  }
+
+  if (hostEnv) {
+    return `http://${hostEnv}`;
+  }
+
+  return `http://127.0.0.1:${fallbackPort}`;
+}
+
+const authBaseUrl = toBaseUrl(
+  process.env.FIREBASE_AUTH_EMULATOR_URL,
+  process.env.FIREBASE_AUTH_EMULATOR_HOST,
+  9199
+);
+const firestoreBaseUrl = toBaseUrl(
+  process.env.FIRESTORE_EMULATOR_URL,
+  process.env.FIRESTORE_EMULATOR_HOST,
+  8180
+);
+const apiKey = 'demo-api-key';
+const timestampFields = new Set(['createdAt', 'updatedAt', 'lastCommentAt']);
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function chatId(userId1, userId2) {
+  const [uidA, uidB] = [String(userId1), String(userId2)].sort();
+  return `dm:v1:${uidA.length}:${uidA}|${uidB.length}:${uidB}`;
+}
+
+function stringField(value) {
+  return { stringValue: value };
+}
+
+function boolField(value) {
+  return { booleanValue: value };
+}
+
+function timestampField(value = nowIso()) {
+  return { timestampValue: value };
+}
+
+function listField(values) {
+  return {
+    arrayValue: {
+      values: values.map((value) => stringField(value))
+    }
+  };
+}
+
+function fields(data) {
+  const result = {};
+
+  Object.entries(data).forEach(([key, value]) => {
+    if (value === undefined) {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      result[key] = listField(value);
+      return;
+    }
+
+    if (typeof value === 'boolean') {
+      result[key] = boolField(value);
+      return;
+    }
+
+    if (typeof value === 'number') {
+      result[key] = { integerValue: String(value) };
+      return;
+    }
+
+    if (timestampFields.has(key)) {
+      result[key] = timestampField(value);
+      return;
+    }
+
+    result[key] = stringField(String(value));
+  });
+
+  return { fields: result };
+}
+
+async function clearFirestore() {
+  const response = await fetch(
+    `${firestoreBaseUrl}/emulator/v1/projects/${projectId}/databases/(default)/documents`,
+    { method: 'DELETE' }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Firestore emulator の初期化に失敗しました: ${response.status}`);
+  }
+}
+
+async function createUser(label) {
+  const email = `${label}-${Date.now()}-${Math.random().toString(16).slice(2)}@example.com`;
+  const response = await fetch(
+    `${authBaseUrl}/identitytoolkit.googleapis.com/v1/accounts:signUp?key=${apiKey}`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        email,
+        password: 'passw0rd!',
+        returnSecureToken: true
+      })
+    }
+  );
+
+  const payload = await response.json();
+  if (!response.ok) {
+    throw new Error(`Auth emulator のユーザー作成に失敗しました: ${JSON.stringify(payload)}`);
+  }
+
+  return {
+    email,
+    uid: payload.localId,
+    idToken: payload.idToken
+  };
+}
+
+async function firestoreRequest({ method = 'GET', path, token, body }) {
+  const response = await fetch(
+    `${firestoreBaseUrl}/v1/projects/${projectId}/databases/(default)/documents/${path}`,
+    {
+      method,
+      headers: {
+        ...(body ? { 'content-type': 'application/json' } : {}),
+        ...(token ? { authorization: `Bearer ${token}` } : {})
+      },
+      body: body ? JSON.stringify(body) : undefined
+    }
+  );
+
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    payload
+  };
+}
+
+function isPermissionDenied(response) {
+  return !response.ok && response.payload?.error?.status === 'PERMISSION_DENIED';
+}
+
+async function expectAllowed(name, request) {
+  const response = await request();
+  if (!response.ok) {
+    throw new Error(`${name} should be allowed but failed: ${response.status} ${JSON.stringify(response.payload)}`);
+  }
+
+  console.log(`PASS: ${name}`);
+  return response;
+}
+
+async function expectDenied(name, request) {
+  const response = await request();
+  if (!isPermissionDenied(response)) {
+    throw new Error(`${name} should be denied but got: ${response.status} ${JSON.stringify(response.payload)}`);
+  }
+
+  console.log(`PASS: ${name}`);
+  return response;
+}
+
+async function run() {
+  await clearFirestore();
+
+  const alice = await createUser('alice');
+  const bob = await createUser('bob');
+  const charlie = await createUser('charlie');
+
+  const aliceProfile = {
+    displayName: 'Alice',
+    username: 'Alice',
+    email: alice.email,
+    profileImageUrl: '',
+    createdAt: nowIso(),
+    updatedAt: nowIso()
+  };
+  const bobProfile = {
+    displayName: 'Bob',
+    username: 'Bob',
+    email: bob.email,
+    profileImageUrl: '',
+    createdAt: nowIso(),
+    updatedAt: nowIso()
+  };
+
+  await expectAllowed('users create by self: alice', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: `users/${alice.uid}`,
+      token: alice.idToken,
+      body: fields(aliceProfile)
+    })
+  );
+
+  await expectAllowed('users create by self: bob', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: `users/${bob.uid}`,
+      token: bob.idToken,
+      body: fields(bobProfile)
+    })
+  );
+
+  await expectDenied('users list without auth', () =>
+    firestoreRequest({ path: 'users' })
+  );
+
+  await expectAllowed('users list with auth', () =>
+    firestoreRequest({
+      path: 'users',
+      token: bob.idToken
+    })
+  );
+
+  await expectDenied('users update by other user', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: `users/${alice.uid}`,
+      token: bob.idToken,
+      body: fields({
+        ...aliceProfile,
+        profileImageUrl: 'https://example.com/hijack.png',
+        updatedAt: nowIso()
+      })
+    })
+  );
+
+  await expectAllowed('users update by self', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: `users/${alice.uid}`,
+      token: alice.idToken,
+      body: fields({
+        ...aliceProfile,
+        isOnline: true,
+        updatedAt: nowIso()
+      })
+    })
+  );
+
+  const threadId = 'thread-alpha';
+  const threadBody = {
+    title: 'Firestore Rules の相談',
+    body: 'Rules をどこまで厳密に検証するべきか確認したいです。',
+    tags: ['firebase', 'rules'],
+    authorId: alice.uid,
+    authorName: 'Alice',
+    createdAt: nowIso(),
+    updatedAt: nowIso()
+  };
+
+  await expectAllowed('threads create by author', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: `threads/${threadId}`,
+      token: alice.idToken,
+      body: fields(threadBody)
+    })
+  );
+
+  await expectDenied('threads read without auth', () =>
+    firestoreRequest({ path: `threads/${threadId}` })
+  );
+
+  await expectAllowed('threads read by authenticated user', () =>
+    firestoreRequest({
+      path: `threads/${threadId}`,
+      token: bob.idToken
+    })
+  );
+
+  await expectDenied('threads update by non-author', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: `threads/${threadId}`,
+      token: bob.idToken,
+      body: fields({
+        ...threadBody,
+        body: '乗っ取り更新',
+        updatedAt: nowIso()
+      })
+    })
+  );
+
+  await expectAllowed('threads update by author', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: `threads/${threadId}`,
+      token: alice.idToken,
+      body: fields({
+        ...threadBody,
+        body: '作成者本人の更新',
+        updatedAt: nowIso()
+      })
+    })
+  );
+
+  const commentId = 'comment-alpha';
+  const commentBody = {
+    body: 'コメント本文',
+    authorId: bob.uid,
+    authorName: 'Bob',
+    createdAt: nowIso(),
+    updatedAt: nowIso()
+  };
+
+  await expectAllowed('comments create by authenticated author', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: `threads/${threadId}/comments/${commentId}`,
+      token: bob.idToken,
+      body: fields(commentBody)
+    })
+  );
+
+  await expectDenied('comments delete by non-author', () =>
+    firestoreRequest({
+      method: 'DELETE',
+      path: `threads/${threadId}/comments/${commentId}`,
+      token: alice.idToken
+    })
+  );
+
+  await expectAllowed('comments update by author', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: `threads/${threadId}/comments/${commentId}`,
+      token: bob.idToken,
+      body: fields({
+        ...commentBody,
+        body: '更新したコメント本文',
+        updatedAt: nowIso()
+      })
+    })
+  );
+
+  const dmId = 'dm-alpha';
+  const dmBody = {
+    chatId: chatId(alice.uid, bob.uid),
+    senderId: alice.uid,
+    senderName: 'Alice',
+    receiverId: bob.uid,
+    text: 'こんにちは',
+    createdAt: nowIso()
+  };
+
+  await expectAllowed('directMessages create by sender', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: `directMessages/${dmId}`,
+      token: alice.idToken,
+      body: fields(dmBody)
+    })
+  );
+
+  await expectAllowed('directMessages read by participant', () =>
+    firestoreRequest({
+      path: `directMessages/${dmId}`,
+      token: bob.idToken
+    })
+  );
+
+  await expectDenied('directMessages read by third party', () =>
+    firestoreRequest({
+      path: `directMessages/${dmId}`,
+      token: charlie.idToken
+    })
+  );
+
+  await expectDenied('directMessages spoofed sender create', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: 'directMessages/dm-spoofed',
+      token: bob.idToken,
+      body: fields({
+        ...dmBody,
+        senderId: alice.uid,
+        senderName: 'Alice',
+        receiverId: charlie.uid,
+        chatId: chatId(alice.uid, charlie.uid),
+        createdAt: nowIso()
+      })
+    })
+  );
+
+  await expectDenied('directMessages update denied', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: `directMessages/${dmId}`,
+      token: alice.idToken,
+      body: fields({
+        ...dmBody,
+        text: '本文の編集は不可',
+        createdAt: nowIso()
+      })
+    })
+  );
+
+  console.log('All Firestore rules checks passed.');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/verify-firestore-rules.mjs
+++ b/scripts/verify-firestore-rules.mjs
@@ -256,6 +256,19 @@ async function run() {
     })
   );
 
+  await expectDenied('users update email by self', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: `users/${alice.uid}`,
+      token: alice.idToken,
+      body: fields({
+        ...aliceProfile,
+        email: bob.email,
+        updatedAt: nowIso()
+      })
+    })
+  );
+
   const threadId = 'thread-alpha';
   const threadBody = {
     title: 'Firestore Rules の相談',
@@ -308,6 +321,20 @@ async function run() {
       body: fields({
         ...threadBody,
         body: '作成者本人の更新',
+        updatedAt: nowIso()
+      })
+    })
+  );
+
+  await expectDenied('threads update derived fields by author', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: `threads/${threadId}`,
+      token: alice.idToken,
+      body: fields({
+        ...threadBody,
+        commentCount: 99,
+        lastCommentAt: nowIso(),
         updatedAt: nowIso()
       })
     })
@@ -395,6 +422,19 @@ async function run() {
         senderId: alice.uid,
         senderName: 'Alice',
         receiverId: charlie.uid,
+        chatId: chatId(alice.uid, charlie.uid),
+        createdAt: nowIso()
+      })
+    })
+  );
+
+  await expectDenied('directMessages mismatched chatId create', () =>
+    firestoreRequest({
+      method: 'PATCH',
+      path: 'directMessages/dm-bad-chat',
+      token: alice.idToken,
+      body: fields({
+        ...dmBody,
         chatId: chatId(alice.uid, charlie.uid),
         createdAt: nowIso()
       })


### PR DESCRIPTION
## 概要

- Firestore Security Rules を `users` `threads` `threads/{threadId}/comments` `directMessages` に追加
- Auth / Firestore Emulator を使う Rules 検証スクリプトと `npm run test:rules` を追加
- emulator ポート設定と session-memory を現状に同期

## 変更内容

- `firestore.rules` を追加し、`users` は本人更新のみ、`threads` / `comments` は author 基準、`directMessages` は当事者 read + sender create に制限
- `firebase.json` に Firestore Rules パスと auth / firestore emulator 設定を追加
- `scripts/verify-firestore-rules.mjs` を追加し、Auth Emulator の ID token を使って許可 / 拒否シナリオを検証
- `package.json` に `npm run test:rules` を追加
- `AGENTS.md` と session-memory を更新

## 検証

- `npm run lint`
- `JAVA_HOME=/tmp/java-runtime/jdk-21.0.10+7-jre/Contents/Home PATH=/tmp/java-runtime/jdk-21.0.10+7-jre/Contents/Home/bin:$PATH npm run test:rules`

## Issue

- Closes #45
