### PR TITLE
chore: import firestore-peek script from prj-team/tmp

### DIFF
--- a/scripts/firestore-peek.js
+++ b/scripts/firestore-peek.js
@@ -1,0 +1,17 @@
+const admin = require('firebase-admin');
+
+admin.initializeApp({
+  credential: admin.credential.cert(require(process.env.GOOGLE_APPLICATION_CREDENTIALS)),
+});
+
+const db = admin.firestore();
+
+(async () => {
+  const collections = await db.listCollections();
+  for (const col of collections) {
+    console.log('COLLECTION:', col.id);
+    const snap = await col.limit(3).get();
+    snap.forEach(doc => console.log(' ', doc.id, doc.data()));
+  }
+})();
+


### PR DESCRIPTION
## Summary
- `~/Documents/prj-team/tmp/firebase-read/read.js` を `vue-chat/scripts/firestore-peek.js` に移設
- 既存の `run-firestore-rules-test.mjs` / `verify-firestore-rules.mjs` と同居させ、Firestore 系ユーティリティを 1 か所に集約

## Test plan
- [ ] `GOOGLE_APPLICATION_CREDENTIALS=path/to/sa.json node scripts/firestore-peek.js` が各コレクションの先頭 3 件を出力する
- [ ] `firebase-admin` を install 済みの環境で実行できる（vue-chat の package.json には未登録なので、必要なら追加 install）

🤖 Generated with [Claude Code](https://claude.com/claude-code)